### PR TITLE
file name error fix

### DIFF
--- a/toolchain/toolchain/python/innercoremodtoolchain/native/native_setup.py
+++ b/toolchain/toolchain/python/innercoremodtoolchain/native/native_setup.py
@@ -63,7 +63,7 @@ def get_ndk_path():
 def search_for_gcc_executable(ndk_dir):
 	search_dir = join(ndk_dir, "bin")
 	if isdir(search_dir):
-		pattern = re.compile("[0-9A-Za-z]*-" + ("windows" if platform.system() == "Windows" else "linux") + "-android(eabi)*-g\\+\\+.*")
+		pattern = re.compile("[0-9A-Za-z]*-linux-android(eabi)*-g\\+\\+.*")
 		for file in listdir(search_dir):
 			if re.match(pattern, file):
 				return abspath(join(search_dir, file))


### PR DESCRIPTION
whether it is windows or linux, the programs' name of ndk use linux